### PR TITLE
feat(service): render static html in spa build

### DIFF
--- a/packages/service/package-lock.json
+++ b/packages/service/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vuesion/service",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10190,6 +10190,11 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
       "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q=="
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -10256,6 +10261,23 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
     },
     "lodash.throttle": {
       "version": "4.1.1",
@@ -15782,6 +15804,50 @@
       "requires": {
         "reflect-metadata": "^0.1.10",
         "vue-class-component": "^6.0.0"
+      }
+    },
+    "vue-server-renderer": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.10.tgz",
+      "integrity": "sha512-UYoCEutBpKzL2fKCwx8zlRtRtwxbPZXKTqbl2iIF4yRZUNO/ovrHyDAJDljft0kd+K0tZhN53XRHkgvCZoIhug==",
+      "requires": {
+        "chalk": "^1.1.3",
+        "hash-sum": "^1.0.2",
+        "he": "^1.1.0",
+        "lodash.template": "^4.4.0",
+        "lodash.uniq": "^4.5.0",
+        "resolve": "^1.2.0",
+        "serialize-javascript": "^1.3.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
       }
     },
     "vue-ssr-webpack-plugin": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -89,7 +89,6 @@
     "ramda": "0.26.1",
     "react": "16.8.1",
     "react-dom": "16.8.1",
-    "rimraf": "2.6.3",
     "sass-loader": "7.1.0",
     "serviceworker-webpack-plugin": "1.0.1",
     "start-server-webpack-plugin": "2.2.5",
@@ -103,6 +102,7 @@
     "typescript": "^3.3.3",
     "vue-jest": "3.0.3",
     "vue-loader": "15.6.2",
+    "vue-server-renderer": "^2.6.10",
     "vue-ssr-webpack-plugin": "3.0.0",
     "webpack": "4.28.4",
     "webpack-bundle-analyzer": "3.0.3",
@@ -116,7 +116,6 @@
     "@types/fs-extra": "5.0.4",
     "@types/ramda": "0.25.48",
     "node-sass": "^4.11.0",
-    "rimraf": "2.6.3",
     "vue-template-compiler": "^2.6.10"
   },
   "publishConfig": {

--- a/packages/service/src/models/Config.ts
+++ b/packages/service/src/models/Config.ts
@@ -21,6 +21,9 @@ export interface IConfig {
   webpack: {
     aliases: { [key: string]: string };
   };
+  spa: {
+    routesToRender: string[];
+  };
 }
 
 export const configPath: string = runtimeRoot('.vuesion/config.json');

--- a/packages/service/src/models/Config.ts
+++ b/packages/service/src/models/Config.ts
@@ -22,7 +22,8 @@ export interface IConfig {
     aliases: { [key: string]: string };
   };
   spa: {
-    routesToRender: string[];
+    appShellRoute: string;
+    additionalRoutes: string[];
   };
 }
 

--- a/packages/service/src/webpack/config/spa.ts
+++ b/packages/service/src/webpack/config/spa.ts
@@ -3,22 +3,15 @@ import { client } from './client';
 import { merge } from './utils';
 import { runtimeRoot } from '../../utils/path';
 
-const HTMLPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 client.plugins.unshift(new webpack.DefinePlugin({ CLIENT: true, SERVER: false, TEST: true }));
 
 export const spa: webpack.Configuration = merge(client, {
   plugins: [
-    new HTMLPlugin({
-      filename: '../index.html',
-      template: runtimeRoot('src/index.template.html'),
-      spa: true,
-    }),
     new CopyWebpackPlugin([
       { from: runtimeRoot('src/static'), to: '../' },
       { from: runtimeRoot('i18n'), to: '../i18n' },
-      { from: runtimeRoot('src/static/logo.png'), to: '../favicon.png' },
     ]),
   ],
 });


### PR DESCRIPTION
closes #26

<!--
There are two main goals in this document, depending on the nature of your PR:

- description: please tell us about your PR
- checklist: please review the checklist

To help to quickly understand the nature of your pull request,
please create a description that incorporates the following elements:
-->

### What is accomplished by your PR?

This PR will add a new flag to the build command `--static` which is the same as `--spa`, the spa build will be replaced at some point with the static build.

The static build allows our users to define an array of routes that should be rendered as part of the build. instead of serving an empty index.html we will now server the content of the `/` route by default. it's already possible to render multiple static pages. they can be defined in the .vuesion/config under the key `spa.routesToRender` e.g. `["/", "/form"]`

### Is there something controversial in your PR?
I am not quite sure if the key `spa.routesToRender` is good enough, I am open for suggestions.

### Link to the Issue
#26 

# Checklist

### New Feature / Bug Fix

- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR

<!--
Thanks for contributing!
-->
